### PR TITLE
From PR feedback

### DIFF
--- a/modules/lotamePanoramaIdSystem.js
+++ b/modules/lotamePanoramaIdSystem.js
@@ -200,24 +200,25 @@ export const lotamePanoramaIdSubmodule = {
       ajax(
         url,
         (response) => {
-          let responseObj = {};
+          let coreId;
           if (response) {
             try {
-              responseObj = JSON.parse(response);
+              let responseObj = JSON.parse(response);
               saveLotameCache(KEY_EXPIRY, responseObj.expiry_ts);
-
-              if (utils.isStr(responseObj.core_id)) {
-                saveLotameCache(
-                  KEY_ID,
-                  responseObj.core_id,
-                  responseObj.expiry_ts
-                );
-              } else {
-                clearLotameCache(KEY_ID);
-              }
 
               if (utils.isStr(responseObj.profile_id)) {
                 setProfileId(responseObj.profile_id);
+
+                if (utils.isStr(responseObj.core_id)) {
+                  saveLotameCache(
+                    KEY_ID,
+                    responseObj.core_id,
+                    responseObj.expiry_ts
+                  );
+                  coreId = responseObj.core_id;
+                } else {
+                  clearLotameCache(KEY_ID);
+                }
               } else {
                 clearLotameCache(KEY_PROFILE);
                 clearLotameCache(KEY_ID);
@@ -226,7 +227,7 @@ export const lotamePanoramaIdSubmodule = {
               utils.logError(error);
             }
           }
-          callback(responseObj);
+          callback(coreId);
         },
         undefined,
         {


### PR DESCRIPTION
This is responding to feedback from Prebid.

The `getId()` change to not return the whole object will cause something like the following to appear when we don't give a panorama id but I "think" it is more correct
```
Prebid ERROR: User ID: lotamePanoramaId - request id responded with an empty value
```

See https://github.com/prebid/Prebid.js/pull/5388 for the notes from the reviewer