### PR TITLE
Lotame panorama id glv

### DIFF
--- a/modules/adxpremiumAnalyticsAdapter.js
+++ b/modules/adxpremiumAnalyticsAdapter.js
@@ -3,6 +3,7 @@ import adapter from '../src/AnalyticsAdapter.js';
 import adapterManager from '../src/adapterManager.js';
 import CONSTANTS from '../src/constants.json';
 import * as utils from '../src/utils.js';
+import includes from 'core-js-pure/features/array/includes.js';
 
 const analyticsType = 'endpoint';
 const defaultUrl = 'https://adxpremium.services/graphql';
@@ -211,7 +212,7 @@ function deviceType() {
 }
 
 function clearSlot(elementId) {
-  if (elementIds.includes(elementId)) { elementIds.splice(elementIds.indexOf(elementId), 1); utils.logInfo('AdxPremium Analytics - Done with: ' + elementId); }
+  if (includes(elementIds, elementId)) { elementIds.splice(elementIds.indexOf(elementId), 1); utils.logInfo('AdxPremium Analytics - Done with: ' + elementId); }
   if (elementIds.length == 0 && !requestSent && !timeoutBased) {
     requestSent = true;
     sendEvent(completeObject);

--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -249,6 +249,14 @@ export const spec = {
       });
     }
 
+    const netidId = utils.deepAccess(bidRequests[0], `userId.netId`);
+    if (netidId) {
+      eids.push({
+        source: 'netid.de',
+        id: netidId
+      });
+    }
+
     const tdid = utils.deepAccess(bidRequests[0], `userId.tdid`);
     if (tdid) {
       eids.push({

--- a/modules/cleanmedianetBidAdapter.js
+++ b/modules/cleanmedianetBidAdapter.js
@@ -3,6 +3,7 @@ import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {config} from '../src/config.js';
 import {Renderer} from '../src/Renderer.js';
 import {BANNER, VIDEO} from '../src/mediaTypes.js';
+import includes from 'core-js-pure/features/array/includes.js';
 
 export const helper = {
   getTopWindowDomain: function (url) {
@@ -119,7 +120,7 @@ export const spec = {
 
       const hasFavoredMediaType =
         params.favoredMediaType &&
-        this.supportedMediaTypes.includes(params.favoredMediaType);
+        includes(this.supportedMediaTypes, params.favoredMediaType);
 
       if (!mediaTypes || mediaTypes.banner) {
         if (!hasFavoredMediaType || params.favoredMediaType === BANNER) {

--- a/modules/dfpAdServerVideo.js
+++ b/modules/dfpAdServerVideo.js
@@ -8,7 +8,7 @@ import { deepAccess, isEmpty, logError, parseSizesInput, formatQS, parseUrl, bui
 import { config } from '../src/config.js';
 import { getHook, submodule } from '../src/hook.js';
 import { auctionManager } from '../src/auctionManager.js';
-import { uspDataHandler } from '../src/adapterManager.js';
+import { gdprDataHandler, uspDataHandler } from '../src/adapterManager.js';
 import events from '../src/events.js';
 import CONSTANTS from '../src/constants.json';
 
@@ -101,6 +101,13 @@ export function buildDfpVideoUrl(options) {
   const descriptionUrl = getDescriptionUrl(bid, options, 'params');
   if (descriptionUrl) { queryParams.description_url = descriptionUrl; }
 
+  const gdprConsent = gdprDataHandler.getConsentData();
+  if (gdprConsent) {
+    if (typeof gdprConsent.gdprApplies === 'boolean') { queryParams.gdpr = Number(gdprConsent.gdprApplies); }
+    if (gdprConsent.consentString) { queryParams.gdpr_consent = gdprConsent.consentString; }
+    if (gdprConsent.addtlConsent) { queryParams.addtl_consent = gdprConsent.addtlConsent; }
+  }
+
   const uspConsent = uspDataHandler.getConsentData();
   if (uspConsent) { queryParams.us_privacy = uspConsent; }
 
@@ -186,6 +193,13 @@ export function buildAdpodVideoUrl({code, params, callback} = {}) {
       params,
       { cust_params: encodedCustomParams }
     );
+
+    const gdprConsent = gdprDataHandler.getConsentData();
+    if (gdprConsent) {
+      if (typeof gdprConsent.gdprApplies === 'boolean') { queryParams.gdpr = Number(gdprConsent.gdprApplies); }
+      if (gdprConsent.consentString) { queryParams.gdpr_consent = gdprConsent.consentString; }
+      if (gdprConsent.addtlConsent) { queryParams.addtl_consent = gdprConsent.addtlConsent; }
+    }
 
     const uspConsent = uspDataHandler.getConsentData();
     if (uspConsent) { queryParams.us_privacy = uspConsent; }

--- a/modules/gamoshiBidAdapter.js
+++ b/modules/gamoshiBidAdapter.js
@@ -3,6 +3,7 @@ import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {config} from '../src/config.js';
 import {Renderer} from '../src/Renderer.js';
 import {BANNER, VIDEO} from '../src/mediaTypes.js';
+import includes from 'core-js-pure/features/array/includes.js';
 
 const ENDPOINTS = {
   'gamoshi': 'https://rtb.gamoshi.io'
@@ -111,7 +112,7 @@ export const spec = {
       };
 
       const hasFavoredMediaType =
-        params.favoredMediaType && this.supportedMediaTypes.includes(params.favoredMediaType);
+        params.favoredMediaType && includes(this.supportedMediaTypes, params.favoredMediaType);
 
       if (!mediaTypes || mediaTypes.banner) {
         if (!hasFavoredMediaType || params.favoredMediaType === BANNER) {

--- a/modules/gjirafaBidAdapter.js
+++ b/modules/gjirafaBidAdapter.js
@@ -49,6 +49,8 @@ export const spec = {
         adUnitId: adUnitId,
         placementId: placementId,
         bidid: bidRequest.bidId,
+        count: bidRequest.params.count,
+        skipTime: bidRequest.params.skipTime
       };
     });
 

--- a/modules/id5IdSystem.js
+++ b/modules/id5IdSystem.js
@@ -16,6 +16,7 @@ const MODULE_NAME = 'id5Id';
 const GVLID = 131;
 const NB_EXP_DAYS = 30;
 export const ID5_STORAGE_NAME = 'id5id';
+export const ID5_PRIVACY_STORAGE_NAME = `${ID5_STORAGE_NAME}_privacy`;
 const LOCAL_STORAGE = 'html5';
 
 // order the legacy cookie names in reverse priority order so the last
@@ -137,6 +138,9 @@ export const id5IdSubmodule = {
             try {
               responseObj = JSON.parse(response);
               resetNb(config.params.partner);
+              if (responseObj.privacy) {
+                storeInLocalStorage(ID5_PRIVACY_STORAGE_NAME, JSON.stringify(responseObj.privacy), NB_EXP_DAYS);
+              }
 
               // TODO: remove after requiring publishers to use localstorage and
               // all publishers have upgraded

--- a/modules/lotamePanoramaIdSystem.js
+++ b/modules/lotamePanoramaIdSystem.js
@@ -16,6 +16,7 @@ const MODULE_NAME = 'lotamePanoramaId';
 const NINE_MONTHS_MS = 23328000 * 1000;
 const DAYS_TO_CACHE = 7;
 const DAY_MS = 60 * 60 * 24 * 1000;
+const GVLID = 95;
 
 export const storage = getStorageManager(null, MODULE_NAME);
 
@@ -141,12 +142,17 @@ function clearLotameCache(key) {
 }
 /** @type {Submodule} */
 export const lotamePanoramaIdSubmodule = {
-
   /**
    * used to link submodule with config
    * @type {string}
    */
   name: MODULE_NAME,
+
+  /**
+   * Vendor id of Lotame
+   * @type {Number}
+   */
+  gvlid: GVLID,
 
   /**
    * Decode the stored id value for passing to bid requests
@@ -156,7 +162,7 @@ export const lotamePanoramaIdSubmodule = {
    * @returns {(Object|undefined)}
    */
   decode(value, config) {
-    return utils.isStr(value) ? { 'lotamePanoramaId': value } : undefined;
+    return utils.isStr(value) ? { lotamePanoramaId: value } : undefined;
   },
 
   /**
@@ -174,7 +180,7 @@ export const lotamePanoramaIdSubmodule = {
 
     if (!refreshNeeded) {
       return {
-        id: localCache.data
+        id: localCache.data,
       };
     }
 
@@ -183,7 +189,7 @@ export const lotamePanoramaIdSubmodule = {
     const resolveIdFunction = function (callback) {
       let queryParams = {};
       if (storedUserId) {
-        queryParams.fp = storedUserId
+        queryParams.fp = storedUserId;
       }
 
       if (consentData && utils.isBoolean(consentData.gdprApplies)) {
@@ -233,7 +239,7 @@ export const lotamePanoramaIdSubmodule = {
         undefined,
         {
           method: 'GET',
-          withCredentials: true
+          withCredentials: true,
         }
       );
     };

--- a/modules/lotamePanoramaIdSystem.js
+++ b/modules/lotamePanoramaIdSystem.js
@@ -18,7 +18,7 @@ const DAYS_TO_CACHE = 7;
 const DAY_MS = 60 * 60 * 24 * 1000;
 const GVLID = 95;
 
-export const storage = getStorageManager(null, MODULE_NAME);
+export const storage = getStorageManager(GVLID, MODULE_NAME);
 
 /**
  * Set the Lotame First Party Profile ID in the first party namespace

--- a/modules/malltvBidAdapter.js
+++ b/modules/malltvBidAdapter.js
@@ -49,6 +49,8 @@ export const spec = {
         adUnitId: adUnitId,
         placementId: placementId,
         bidid: bidRequest.bidId,
+        count: bidRequest.params.count,
+        skipTime: bidRequest.params.skipTime
       };
     });
 

--- a/modules/medianetAnalyticsAdapter.js
+++ b/modules/medianetAnalyticsAdapter.js
@@ -4,7 +4,8 @@ import CONSTANTS from '../src/constants.json';
 import * as utils from '../src/utils.js';
 import { ajax } from '../src/ajax.js';
 import { getRefererInfo } from '../src/refererDetection.js';
-import { AUCTION_COMPLETED, AUCTION_IN_PROGRESS, getPriceGranularity } from '../src/auction.js'
+import { AUCTION_COMPLETED, AUCTION_IN_PROGRESS, getPriceGranularity } from '../src/auction.js';
+import includes from 'core-js-pure/features/array/includes.js';
 
 const analyticsType = 'endpoint';
 const ENDPOINT = 'https://pb-logs.media.net/log?logid=kfk&evtid=prebid_analytics_events_client';
@@ -125,7 +126,7 @@ class Configure {
       this.setDataFromResponse(response);
       this.overrideDomainLevelData(response);
       this.overrideToDebug(this.mnetDebugConfig);
-      this.urlToConsume = VALID_URL_KEY.includes(response.urlKey) ? response.urlKey : this.urlToConsume;
+      this.urlToConsume = includes(VALID_URL_KEY, response.urlKey) ? response.urlKey : this.urlToConsume;
       this.ajaxState = CONFIG_PASS;
     } catch (e) {
       this.ajaxState = CONFIG_ERROR;

--- a/modules/riseBidAdapter.js
+++ b/modules/riseBidAdapter.js
@@ -1,0 +1,250 @@
+import {registerBidder} from '../src/adapters/bidderFactory.js';
+import * as utils from '../src/utils.js';
+import {VIDEO} from '../src/mediaTypes.js';
+import {config} from '../src/config.js';
+
+const SUPPORTED_AD_TYPES = [VIDEO];
+const BIDDER_CODE = 'rise';
+const BIDDER_VERSION = '4.0.0';
+const TTL = 360;
+const SELLER_ENDPOINT = 'https://hb.yellowblue.io/';
+const MODES = {
+  PRODUCTION: 'hb',
+  TEST: 'hb-test'
+}
+const SUPPORTED_SYNC_METHODS = {
+  IFRAME: 'iframe',
+  PIXEL: 'pixel'
+}
+
+export const spec = {
+  code: BIDDER_CODE,
+  version: BIDDER_VERSION,
+  supportedMediaTypes: SUPPORTED_AD_TYPES,
+  isBidRequestValid: function(bidRequest) {
+    return !!(bidRequest.params.org);
+  },
+  buildRequests: function (bidRequests, bidderRequest) {
+    if (bidRequests.length === 0) {
+      return [];
+    }
+
+    const requests = [];
+
+    bidRequests.forEach(bid => {
+      requests.push(buildVideoRequest(bid, bidderRequest));
+    });
+
+    return requests;
+  },
+  interpretResponse: function({body}) {
+    const bidResponses = [];
+
+    const bidResponse = {
+      requestId: body.requestId,
+      cpm: body.cpm,
+      width: body.width,
+      height: body.height,
+      creativeId: body.requestId,
+      currency: body.currency,
+      netRevenue: body.netRevenue,
+      ttl: body.ttl || TTL,
+      vastXml: body.vastXml,
+      mediaType: VIDEO
+    };
+
+    bidResponses.push(bidResponse);
+
+    return bidResponses;
+  },
+  getUserSyncs: function(syncOptions, serverResponses) {
+    const syncs = [];
+    for (const response of serverResponses) {
+      if (syncOptions.iframeEnabled && response.body.userSyncURL) {
+        syncs.push({
+          type: 'iframe',
+          url: response.body.userSyncURL
+        });
+      }
+      if (syncOptions.pixelEnabled && utils.isArray(response.body.userSyncPixels)) {
+        const pixels = response.body.userSyncPixels.map(pixel => {
+          return {
+            type: 'image',
+            url: pixel
+          }
+        })
+        syncs.push(...pixels)
+      }
+    }
+    return syncs;
+  }
+};
+
+registerBidder(spec);
+
+/**
+ * Build the video request
+ * @param bid {bid}
+ * @param bidderRequest {bidderRequest}
+ * @returns {Object}
+ */
+function buildVideoRequest(bid, bidderRequest) {
+  const sellerParams = generateParameters(bid, bidderRequest);
+  const {params} = bid;
+  return {
+    method: 'GET',
+    url: getEndpoint(params.testMode),
+    data: sellerParams
+  };
+}
+
+/**
+ * Get the the ad size from the bid
+ * @param bid {bid}
+ * @returns {Array}
+ */
+function getSizes(bid) {
+  if (utils.deepAccess(bid, 'mediaTypes.video.sizes')) {
+    return bid.mediaTypes.video.sizes[0];
+  } else if (Array.isArray(bid.sizes) && bid.sizes.length > 0) {
+    return bid.sizes[0];
+  }
+  return [];
+}
+
+/**
+ * Get schain string value
+ * @param schainObject {Object}
+ * @returns {string}
+ */
+function getSupplyChain(schainObject) {
+  if (utils.isEmpty(schainObject)) {
+    return '';
+  }
+  let scStr = `${schainObject.ver},${schainObject.complete}`;
+  schainObject.nodes.forEach((node) => {
+    scStr += '!';
+    scStr += `${getEncodedValIfNotEmpty(node.asi)},`;
+    scStr += `${getEncodedValIfNotEmpty(node.sid)},`;
+    scStr += `${getEncodedValIfNotEmpty(node.hp)},`;
+    scStr += `${getEncodedValIfNotEmpty(node.rid)},`;
+    scStr += `${getEncodedValIfNotEmpty(node.name)},`;
+    scStr += `${getEncodedValIfNotEmpty(node.domain)}`;
+  });
+  return scStr;
+}
+
+/**
+ * Get encoded node value
+ * @param val {string}
+ * @returns {string}
+ */
+function getEncodedValIfNotEmpty(val) {
+  return !utils.isEmpty(val) ? encodeURIComponent(val) : '';
+}
+
+/**
+ * Get preferred user-sync method based on publisher configuration
+ * @param bidderCode {string}
+ * @returns {string}
+ */
+function getAllowedSyncMethod(filterSettings, bidderCode) {
+  const iframeConfigsToCheck = ['all', 'iframe'];
+  const pixelConfigToCheck = 'image';
+  if (filterSettings && iframeConfigsToCheck.some(config => isSyncMethodAllowed(filterSettings[config], bidderCode))) {
+    return SUPPORTED_SYNC_METHODS.IFRAME;
+  }
+  if (!filterSettings || !filterSettings[pixelConfigToCheck] || isSyncMethodAllowed(filterSettings[pixelConfigToCheck], bidderCode)) {
+    return SUPPORTED_SYNC_METHODS.PIXEL;
+  }
+}
+
+/**
+ * Check if sync rule is supported
+ * @param syncRule {Object}
+ * @param bidderCode {string}
+ * @returns {boolean}
+ */
+function isSyncMethodAllowed(syncRule, bidderCode) {
+  if (!syncRule) {
+    return false;
+  }
+  const isInclude = syncRule.filter === 'include';
+  const bidders = utils.isArray(syncRule.bidders) ? syncRule.bidders : [bidderCode];
+  return isInclude && utils.contains(bidders, bidderCode);
+}
+
+/**
+ * Get the seller endpoint
+ * @param testMode {boolean}
+ * @returns {string}
+ */
+function getEndpoint(testMode) {
+  return testMode
+    ? SELLER_ENDPOINT + MODES.TEST
+    : SELLER_ENDPOINT + MODES.PRODUCTION;
+}
+
+/**
+ * Generate query parameters for the request
+ * @param bid {bid}
+ * @param bidderRequest {bidderRequest}
+ * @returns {Object}
+ */
+function generateParameters(bid, bidderRequest) {
+  const timeout = config.getConfig('bidderTimeout');
+  const { syncEnabled, filterSettings } = config.getConfig('userSync') || {};
+  const [ width, height ] = getSizes(bid);
+  const { params } = bid;
+  const { bidderCode } = bidderRequest;
+  const domain = window.location.hostname;
+
+  const requestParams = {
+    auction_start: utils.timestamp(),
+    ad_unit_code: utils.getBidIdParameter('adUnitCode', bid),
+    tmax: timeout,
+    width: width,
+    height: height,
+    publisher_id: params.org,
+    floor_price: params.floorPrice,
+    ua: navigator.userAgent,
+    bid_id: utils.getBidIdParameter('bidId', bid),
+    bidder_request_id: utils.getBidIdParameter('bidderRequestId', bid),
+    transaction_id: utils.getBidIdParameter('transactionId', bid),
+    session_id: utils.getBidIdParameter('auctionId', bid),
+    publisher_name: domain,
+    site_domain: domain,
+    bidder_version: BIDDER_VERSION
+  };
+
+  if (syncEnabled) {
+    const allowedSyncMethod = getAllowedSyncMethod(filterSettings, bidderCode);
+    if (allowedSyncMethod) {
+      requestParams.cs_method = allowedSyncMethod;
+    }
+  }
+
+  if (bidderRequest.uspConsent) {
+    requestParams.us_privacy = bidderRequest.uspConsent;
+  }
+
+  if (bidderRequest && bidderRequest.gdprConsent && bidderRequest.gdprConsent.gdprApplies) {
+    requestParams.gdpr = bidderRequest.gdprConsent.gdprApplies;
+    requestParams.gdpr_consent = bidderRequest.gdprConsent.consentString;
+  }
+
+  if (params.ifa) {
+    requestParams.ifa = params.ifa;
+  }
+
+  if (bid.schain) {
+    requestParams.schain = getSupplyChain(bid.schain);
+  }
+
+  if (bidderRequest && bidderRequest.refererInfo) {
+    requestParams.referrer = utils.deepAccess(bidderRequest, 'refererInfo.referer');
+    requestParams.page_url = config.getConfig('pageUrl') || utils.deepAccess(window, 'location.href');
+  }
+
+  return requestParams;
+}

--- a/modules/riseBidAdapter.md
+++ b/modules/riseBidAdapter.md
@@ -1,0 +1,51 @@
+#Overview
+
+Module Name: Rise Bidder Adapter
+
+Module Type: Bidder Adapter
+
+Maintainer: prebid-rise-engage@risecodes.com
+
+
+# Description
+
+Module that connects to Rise's demand sources.
+
+The Rise adapter requires setup and approval from the Rise. Please reach out to prebid-rise-engage@risecodes.com to create an Rise account.
+
+The adapter supports Video(instream). For the integration, Rise returns content as vastXML and requires the publisher to define the cache url in config passed to Prebid for it to be valid in the auction.
+
+# Bid Parameters
+## Video
+
+| Name | Scope | Type | Description | Example
+| ---- | ----- | ---- | ----------- | -------
+| `org` | required | String |  Rise publisher Id provided by your Rise representative  | "56f91cd4d3e3660002000033"
+| `floorPrice` | optional | Number |  Minimum price in USD. Misuse of this parameter can impact revenue | 2.00
+| `ifa` | optional | String |  The ID for advertisers (also referred to as "IDFA")  | "XXX-XXX"
+| `testMode` | optional | Boolean |  This activates the test mode  | false
+
+# Test Parameters
+```javascript
+var adUnits = [
+       {
+        code: 'dfp-video-div',
+        sizes: [[640, 480]],
+        mediaTypes: {
+          video: {
+            playerSize: [[640, 480]],
+            context: 'instream'
+          }
+        },
+        bids: [{
+          bidder: 'rise',
+          params: {
+            org: '56f91cd4d3e3660002000033', // Required
+            floorPrice: 2.00, // Optional
+            ifa: 'XXX-XXX', // Optional
+            testMode: false // Optional
+          }
+        }]
+      }
+   ];
+```

--- a/modules/sspBCBidAdapter.js
+++ b/modules/sspBCBidAdapter.js
@@ -2,6 +2,7 @@ import * as utils from '../src/utils.js';
 import { ajax } from '../src/ajax.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { BANNER } from '../src/mediaTypes.js';
+import strIncludes from 'core-js-pure/features/string/includes.js';
 
 const BIDDER_CODE = 'sspBC';
 const BIDDER_URL = 'https://ssp.wp.pl/bidder/';
@@ -314,7 +315,7 @@ const spec = {
             site.slot = serverBid.ext.slotid || site.slot;
           }
 
-          if (bidRequest && site.id && !site.id.includes('bidid')) {
+          if (bidRequest && site.id && !strIncludes(site.id, 'bidid')) {
             // store site data for future notification
             oneCodeDetection[bidRequest.bidId] = [site.id, site.slot];
 

--- a/modules/synacormediaBidAdapter.js
+++ b/modules/synacormediaBidAdapter.js
@@ -24,7 +24,7 @@ export const spec = {
       bid.mediaTypes.hasOwnProperty('video');
   },
   isBidRequestValid: function(bid) {
-    const hasRequiredParams = bid && bid.params && bid.params.hasOwnProperty('placementId') && bid.params.hasOwnProperty('seatId');
+    const hasRequiredParams = bid && bid.params && (bid.params.hasOwnProperty('placementId') || bid.params.hasOwnProperty('tagId')) && bid.params.hasOwnProperty('seatId');
     const hasAdSizes = bid && getAdUnitSizes(bid).filter(size => BLOCKED_AD_SIZES.indexOf(size.join('x')) === -1).length > 0
     return !!(hasRequiredParams && hasAdSizes);
   },
@@ -61,7 +61,7 @@ export const spec = {
       } else {
         seatId = bid.params.seatId;
       }
-      const placementId = bid.params.placementId;
+      const tagIdOrplacementId = bid.params.tagId || bid.params.placementId;
       const bidFloor = bid.params.bidfloor ? parseFloat(bid.params.bidfloor) : null;
       if (isNaN(bidFloor)) {
         logWarn(`Synacormedia: there is an invalid bid floor: ${bid.params.bidfloor}`);
@@ -77,9 +77,9 @@ export const spec = {
 
       let imps = [];
       if (videoOrBannerKey === 'banner') {
-        imps = this.buildBannerImpressions(adSizes, bid, placementId, pos, bidFloor, videoOrBannerKey);
+        imps = this.buildBannerImpressions(adSizes, bid, tagIdOrplacementId, pos, bidFloor, videoOrBannerKey);
       } else if (videoOrBannerKey === 'video') {
-        imps = this.buildVideoImpressions(adSizes, bid, placementId, pos, bidFloor, videoOrBannerKey);
+        imps = this.buildVideoImpressions(adSizes, bid, tagIdOrplacementId, pos, bidFloor, videoOrBannerKey);
       }
       if (imps.length > 0) {
         imps.forEach(i => openRtbBidRequest.imp.push(i));
@@ -104,7 +104,7 @@ export const spec = {
     }
   },
 
-  buildBannerImpressions: function(adSizes, bid, placementId, pos, bidFloor, videoOrBannerKey) {
+  buildBannerImpressions: function (adSizes, bid, tagIdOrPlacementId, pos, bidFloor, videoOrBannerKey) {
     let format = [];
     let imps = [];
     adSizes.forEach((size, i) => {
@@ -125,7 +125,7 @@ export const spec = {
           format,
           pos
         },
-        tagid: placementId,
+        tagid: tagIdOrPlacementId,
       };
       if (bidFloor !== null && !isNaN(bidFloor)) {
         imp.bidfloor = bidFloor;
@@ -135,7 +135,7 @@ export const spec = {
     return imps;
   },
 
-  buildVideoImpressions: function(adSizes, bid, placementId, pos, bidFloor, videoOrBannerKey) {
+  buildVideoImpressions: function(adSizes, bid, tagIdOrPlacementId, pos, bidFloor, videoOrBannerKey) {
     let imps = [];
     adSizes.forEach((size, i) => {
       if (!size || size.length != 2) {
@@ -145,7 +145,7 @@ export const spec = {
       const size1 = size[1];
       const imp = {
         id: `${videoOrBannerKey.substring(0, 1)}${bid.bidId}-${size0}x${size1}`,
-        tagid: placementId
+        tagid: tagIdOrPlacementId
       };
       if (bidFloor !== null && !isNaN(bidFloor)) {
         imp.bidfloor = bidFloor;

--- a/modules/synacormediaBidAdapter.md
+++ b/modules/synacormediaBidAdapter.md
@@ -33,7 +33,7 @@ https://track.technoratimedia.com/openrtb/tags?ID=%%PATTERN:hb_cache_id_synacorm
           bidder: "synacormedia",
           params: {
               seatId: "prebid",
-              placementId: "demo1",
+              tagId: "demo1",
               bidfloor: 0.10,
               pos: 1
           }
@@ -52,7 +52,7 @@ https://track.technoratimedia.com/openrtb/tags?ID=%%PATTERN:hb_cache_id_synacorm
           bidder: "synacormedia",
           params: {
               seatId: "prebid",
-              placementId: "demo1",
+              tagId: "demo1",
               bidfloor: 0.20,
               pos: 1,
               video: {

--- a/modules/temedyaBidAdapter.js
+++ b/modules/temedyaBidAdapter.js
@@ -1,0 +1,144 @@
+import * as utils from '../src/utils.js';
+import { registerBidder } from '../src/adapters/bidderFactory.js';
+import { BANNER, NATIVE } from '../src/mediaTypes.js';
+
+const BIDDER_CODE = 'temedya';
+const ENDPOINT_URL = 'https://adm.vidyome.com/';
+const ENDPOINT_METHOD = 'GET';
+const CURRENCY = 'TRY';
+
+export const spec = {
+  code: BIDDER_CODE,
+  supportedMediaTypes: [BANNER, NATIVE],
+  /**
+  * Determines whether or not the given bid request is valid.
+  *
+  * @param {BidRequest} bid The bid params to validate.
+  * @return boolean True if this is a valid bid, and false otherwise.
+  */
+  isBidRequestValid: function (bid) {
+    return !!(bid.params.widgetId);
+  },
+  /**
+  * Make a server request from the list of BidRequests.
+  *
+  * @param {validBidRequests[]} - an array of bids
+  * @return ServerRequest Info describing the request to the server.
+  */
+  buildRequests: function (validBidRequests, bidderRequest) {
+    return validBidRequests.map(req => {
+      const mediaType = this._isBannerRequest(req) ? 'display' : NATIVE;
+      const data = {
+        wid: req.params.widgetId,
+        type: mediaType,
+        count: (req.params.count > 6 ? 6 : req.params.count) || 1,
+        mediaType: mediaType,
+        requestid: req.bidId
+      };
+      if (mediaType === 'display') {
+        data.sizes = utils.parseSizesInput(
+          req.mediaTypes && req.mediaTypes.banner && req.mediaTypes.banner.sizes
+        ).join('|')
+      }
+      /** @type {ServerRequest} */
+      return {
+        method: ENDPOINT_METHOD,
+        url: ENDPOINT_URL,
+        data: utils.parseQueryStringParameters(data),
+        options: { withCredentials: false, requestId: req.bidId, mediaType: mediaType }
+      };
+    });
+  },
+  /**
+  * Unpack the response from the server into a list of bids.
+  *
+  * @param {ServerResponse} serverResponse A successful response from the server.
+  * @return {Bid[]} An array of bids which were nested inside the server.
+  */
+  interpretResponse: function (serverResponse, bidRequest) {
+    try {
+      const bidResponse = serverResponse.body;
+      const bidResponses = [];
+      if (bidResponse && bidRequest.options.mediaType == NATIVE) {
+        bidResponse.ads.forEach(function(ad) {
+          bidResponses.push({
+            requestId: bidRequest.options.requestId,
+            cpm: parseFloat(ad.assets.cpm) || 1,
+            width: 320,
+            height: 240,
+            creativeId: ad.assets.id,
+            currency: ad.currency || CURRENCY,
+            netRevenue: false,
+            mediaType: NATIVE,
+            ttl: 360,
+            native: {
+              title: ad.assets.title,
+              body: ad.assets.body || '',
+              icon: {
+                url: ad.assets.files[0],
+                width: 320,
+                height: 240
+              },
+              image: {
+                url: ad.assets.files[0],
+                width: 320,
+                height: 240
+              },
+              privacyLink: '',
+              clickUrl: ad.assets.click_url,
+              displayUrl: ad.assets.click_url,
+              cta: '',
+              sponsoredBy: ad.assets.sponsor || '',
+              impressionTrackers: [bidResponse.base.widget.impression + '&ids=' + ad.id + ':' + ad.assets.id],
+            },
+          });
+        });
+      } else if (bidResponse && bidRequest.options.mediaType == 'display') {
+        bidResponse.ads.forEach(function(ad) {
+          let w = ad.assets.width || 300;
+          let h = ad.assets.height || 250;
+          let htmlTag = '<!doctype html><html><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"><link rel="stylesheet" href="https://widget.cdn.vidyome.com/builds/neytivme.css"></head>';
+          htmlTag += '<body><div id="tem_banner" class="size' + w + '-' + h + '" style="width:' + w + 'px;height:' + h + 'px">';
+          htmlTag += '<i onclick="window.open(\'https://www.temedya.com\', \'_blank\')">TE Medya</i>';
+          htmlTag += '<a href="' + ad.assets.click_url + '" target="_blank">';
+          htmlTag += '<div class="image-with-text">';
+          htmlTag += '<div class="tem-img"><img src="' + ad.assets.files[0] + '" style="width:' + w + 'px;height:' + h + 'px;"/></div>';
+          if (ad.assets.title) {
+            htmlTag += '<div class="text-elements">';
+            htmlTag += '<h2>' + ad.assets.title + '</h2>';
+            htmlTag += '<p>' + (ad.assets.sponsor || '') + '</p>';
+            htmlTag += '<em><canvas height="100" width="100"></canvas></em>';
+            htmlTag += '</div>';
+          };
+          htmlTag += '</div></a><img style="display: none;" src="' + bidResponse.base.widget.impression + '&ids=' + ad.id + ':' + ad.assets.id + '">';
+          htmlTag += '</div></body></html>';
+          bidResponses.push({
+            requestId: bidRequest.options.requestId,
+            cpm: parseFloat(ad.assets.cpm) || 1,
+            width: w,
+            height: h,
+            creativeId: ad.assets.id,
+            currency: ad.currency || CURRENCY,
+            netRevenue: false,
+            ttl: 360,
+            mediaType: BANNER,
+            ad: htmlTag
+          });
+        });
+      }
+      return bidResponses;
+    } catch (err) {
+      utils.logError(err);
+      return [];
+    }
+  },
+  /**
+   * @param {BidRequest} req
+   * @return {boolean}
+   * @private
+   */
+  _isBannerRequest(req) {
+    return !!(req.mediaTypes && req.mediaTypes.banner);
+  }
+}
+registerBidder(spec);

--- a/modules/temedyaBidAdapter.md
+++ b/modules/temedyaBidAdapter.md
@@ -1,0 +1,64 @@
+# Overview
+
+Module Name: TE Medya Bidder Adapter
+Module Type: Bidder Adapter
+Maintainer: prebid@temedya.com
+
+# Description
+
+Module that connects to TE Medya's demand sources.
+
+TE Medya supports Native and Banner. 
+
+
+# Test Parameters
+# Native
+```
+
+    var adUnits = [
+        {
+            code:'tme_div_id',
+            mediaTypes:{
+                native: {
+                    title: {
+                        required: true
+                    }
+                }
+            },
+            bids:[
+                {
+                    bidder: 'temedya',
+                    params: {
+                        widgetId: 753497,
+                        count: 1
+                    }
+                }
+            ]
+        }
+    ];
+```
+# Test Parameters
+# Banner
+```
+
+    var adUnits = [
+        {
+            code:'tme_div_id',
+            mediaTypes:{
+                banner: {
+                    banner: {
+                        sizes:[300, 250]
+                    }
+                }
+            },
+            bids:[
+                {
+                    bidder: 'temedya',
+                    params: {
+                        widgetId: 753497
+                    }
+                }
+            ]
+        }
+    ];
+```

--- a/modules/ucfunnelBidAdapter.js
+++ b/modules/ucfunnelBidAdapter.js
@@ -1,12 +1,13 @@
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {BANNER, VIDEO, NATIVE} from '../src/mediaTypes.js';
 import { getStorageManager } from '../src/storageManager.js';
+import { config } from '../src/config.js';
 import * as utils from '../src/utils.js';
 const storage = getStorageManager();
 const COOKIE_NAME = 'ucf_uid';
 const VER = 'ADGENT_PREBID-2018011501';
 const BIDDER_CODE = 'ucfunnel';
-
+const GVLID = 607;
 const VIDEO_CONTEXT = {
   INSTREAM: 0,
   OUSTREAM: 2
@@ -14,6 +15,7 @@ const VIDEO_CONTEXT = {
 
 export const spec = {
   code: BIDDER_CODE,
+  gvlid: GVLID,
   ENDPOINT: 'https://hb.aralego.com/header',
   supportedMediaTypes: [BANNER, VIDEO, NATIVE],
   /**
@@ -65,11 +67,12 @@ export const spec = {
     let bid = {
       requestId: bidRequest.bidId,
       cpm: ad.cpm || 0,
-      creativeId: ad.ad_id || bidRequest.params.adid,
+      creativeId: ad.crid || ad.ad_id || bidRequest.params.adid,
       dealId: ad.deal || null,
       currency: 'USD',
       netRevenue: true,
-      ttl: 1800
+      ttl: 1800,
+      meta: {}
     };
 
     if (bidRequest.params && bidRequest.params.bidfloor && ad.cpm && ad.cpm < bidRequest.params.bidfloor) {
@@ -77,6 +80,10 @@ export const spec = {
     }
     if (ad.creative_type) {
       bid.mediaType = ad.creative_type;
+      bid.meta.mediaType = ad.creative_type;
+    }
+    if (ad.adomain) {
+      bid.meta.advertiserDomains = ad.adomain;
     }
 
     switch (ad.creative_type) {
@@ -124,16 +131,19 @@ export const spec = {
     return [bid];
   },
 
-  getUserSyncs: function(syncOptions) {
+  getUserSyncs: function(syncOptions, serverResponses, gdprConsent = {}, uspConsent) {
+    let gdprApplies = (gdprConsent && gdprConsent.gdprApplies) ? '1' : '';
+    let apiVersion = (gdprConsent) ? gdprConsent.apiVersion : '';
+    let consentString = (gdprConsent) ? gdprConsent.consentString : '';
     if (syncOptions.iframeEnabled) {
       return [{
         type: 'iframe',
-        url: 'https://cdn.aralego.net/ucfad/cookie/sync.html'
+        url: 'https://cdn.aralego.net/ucfad/cookie/sync.html' + getCookieSyncParameter(gdprApplies, apiVersion, consentString, uspConsent)
       }];
     } else if (syncOptions.pixelEnabled) {
       return [{
         type: 'image',
-        url: 'https://sync.aralego.com/idSync'
+        url: 'https://sync.aralego.com/idSync' + getCookieSyncParameter(gdprApplies, apiVersion, consentString, uspConsent)
       }];
     }
   }
@@ -144,6 +154,22 @@ function transformSizes(requestSizes) {
   if (typeof requestSizes === 'object' && requestSizes.length) {
     return requestSizes[0];
   }
+}
+
+function getCookieSyncParameter(gdprApplies, apiVersion, consentString, uspConsent) {
+  let param = '?';
+  if (gdprApplies == '1') {
+    param = param + 'gdpr=1&';
+  }
+  if (apiVersion == 1) {
+    param = param + 'euconsent=' + consentString + '&';
+  } else if (apiVersion == 2) {
+    param = param + 'euconsent-v2=' + consentString + '&';
+  }
+  if (uspConsent) {
+    param = param + 'usprivacy=' + uspConsent;
+  }
+  return (param == '?') ? '' : param;
 }
 
 function parseSizes(bid) {
@@ -202,14 +228,14 @@ function getRequestData(bid, bidderRequest) {
     schain: supplyChain,
     fp: bid.params.bidfloor
   };
-
+  addUserId(bidData, bid.userId);
   try {
     bidData.host = window.top.location.hostname;
-    bidData.u = window.top.location.href;
+    bidData.u = config.getConfig('publisherDomain') || window.top.location.href;
     bidData.xr = 0;
   } catch (e) {
     bidData.host = window.location.hostname;
-    bidData.u = document.referrer || window.location.href;
+    bidData.u = config.getConfig('publisherDomain') || bidderRequest.refererInfo.referrer || document.referrer || window.location.href;
     bidData.xr = 1;
   }
 
@@ -253,11 +279,63 @@ function getRequestData(bid, bidderRequest) {
   }
 
   if (bidderRequest && bidderRequest.gdprConsent) {
-    Object.assign(bidData, {
-      gdpr: bidderRequest.gdprConsent.gdprApplies ? 1 : 0,
-      euconsent: bidderRequest.gdprConsent.consentString
-    });
+    if (bidderRequest.gdprConsent.apiVersion == 1) {
+      Object.assign(bidData, {
+        gdpr: bidderRequest.gdprConsent.gdprApplies ? 1 : 0,
+        euconsent: bidderRequest.gdprConsent.consentString
+      });
+    } else if (bidderRequest.gdprConsent.apiVersion == 2) {
+      Object.assign(bidData, {
+        gdpr: bidderRequest.gdprConsent.gdprApplies ? 1 : 0,
+        'euconsent-v2': bidderRequest.gdprConsent.consentString
+      });
+    }
   }
+
+  if (config.getConfig('coppa')) {
+    bidData.coppa = true;
+  }
+
+  return bidData;
+}
+
+function addUserId(bidData, userId) {
+  utils._each(userId, (userIdObjectOrValue, userIdProviderKey) => {
+    switch (userIdProviderKey) {
+      case 'sharedid':
+        if (userIdObjectOrValue.id) {
+          bidData[userIdProviderKey + '_id'] = userIdObjectOrValue.id;
+        }
+        if (userIdObjectOrValue.third) {
+          bidData[userIdProviderKey + '_third'] = userIdObjectOrValue.third;
+        }
+        break;
+      case 'haloId':
+        if (userIdObjectOrValue.haloId) {
+          bidData[userIdProviderKey + 'haloId'] = userIdObjectOrValue.haloId;
+        }
+        if (userIdObjectOrValue.auSeg) {
+          bidData[userIdProviderKey + '_auSeg'] = userIdObjectOrValue.auSeg;
+        }
+        break;
+      case 'parrableId':
+        if (userIdObjectOrValue.eid) {
+          bidData[userIdProviderKey + '_eid'] = userIdObjectOrValue.eid;
+        }
+        break;
+      case 'id5id':
+        if (userIdObjectOrValue.uid) {
+          bidData[userIdProviderKey + '_uid'] = userIdObjectOrValue.uid;
+        }
+        if (userIdObjectOrValue.ext && userIdObjectOrValue.ext.linkType) {
+          bidData[userIdProviderKey + '_linkType'] = userIdObjectOrValue.ext.linkType;
+        }
+        break;
+      default:
+        bidData[userIdProviderKey] = userIdObjectOrValue;
+        break;
+    }
+  });
 
   return bidData;
 }

--- a/modules/verizonMediaIdSystem.js
+++ b/modules/verizonMediaIdSystem.js
@@ -8,6 +8,7 @@
 import {ajax} from '../src/ajax.js';
 import {submodule} from '../src/hook.js';
 import * as utils from '../src/utils.js';
+import includes from 'core-js-pure/features/array/includes.js';
 
 const MODULE_NAME = 'verizonMediaId';
 const VENDOR_ID = 25;
@@ -55,7 +56,7 @@ export const verizonMediaIdSubmodule = {
     }
 
     const data = {
-      '1p': [1, '1', true].includes(params['1p']) ? '1' : '0',
+      '1p': includes([1, '1', true], params['1p']) ? '1' : '0',
       he: params.he,
       gdpr: isEUConsentRequired(consentData) ? '1' : '0',
       euconsent: isEUConsentRequired(consentData) ? consentData.gdpr.consentString : '',

--- a/modules/yieldmoBidAdapter.js
+++ b/modules/yieldmoBidAdapter.js
@@ -2,6 +2,7 @@ import * as utils from '../src/utils.js';
 import { BANNER, VIDEO } from '../src/mediaTypes.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import includes from 'core-js-pure/features/array/includes';
+import find from 'core-js-pure/features/array/find.js';
 
 const BIDDER_CODE = 'yieldmo';
 const CURRENCY = 'USD';
@@ -197,7 +198,7 @@ function createNewBannerBid(response) {
  * @param bidRequest server request
  */
 function createNewVideoBid(response, bidRequest) {
-  const imp = (utils.deepAccess(bidRequest, 'data.imp') || []).find(imp => imp.id === response.impid);
+  const imp = find((utils.deepAccess(bidRequest, 'data.imp') || []), imp => imp.id === response.impid);
   return {
     requestId: imp.id,
     cpm: response.price,

--- a/modules/yuktamediaAnalyticsAdapter.js
+++ b/modules/yuktamediaAnalyticsAdapter.js
@@ -5,6 +5,7 @@ import CONSTANTS from '../src/constants.json';
 import * as utils from '../src/utils.js';
 import { getStorageManager } from '../src/storageManager.js';
 import { getRefererInfo } from '../src/refererDetection.js';
+import strIncludes from 'core-js-pure/features/string/includes.js';
 
 const storage = getStorageManager();
 const yuktamediaAnalyticsVersion = 'v3.1.0';
@@ -152,7 +153,7 @@ var yuktamediaAnalyticsAdapter = Object.assign(adapter({ analyticsType: 'endpoin
               bidResponse.responseTimestamp = args.responseTimestamp;
               bidResponse.bidForSize = args.size;
               for (const [adserverTargetingKey, adserverTargetingValue] of Object.entries(args.adserverTargeting)) {
-                if (['body', 'icon', 'image', 'linkurl', 'host', 'path'].every((ele) => !adserverTargetingKey.includes(ele))) {
+                if (['body', 'icon', 'image', 'linkurl', 'host', 'path'].every((ele) => !strIncludes(adserverTargetingKey, ele))) {
                   bidResponse['adserverTargeting-' + adserverTargetingKey] = adserverTargetingValue;
                 }
               }

--- a/src/targeting.js
+++ b/src/targeting.js
@@ -5,6 +5,7 @@ import { auctionManager } from './auctionManager.js';
 import { sizeSupported } from './sizeMapping.js';
 import { ADPOD } from './mediaTypes.js';
 import includes from 'core-js-pure/features/array/includes.js';
+import find from 'core-js-pure/features/array/find.js';
 
 const utils = require('./utils.js');
 var CONSTANTS = require('./constants.json');
@@ -200,7 +201,7 @@ export function newTargeting(auctionManager) {
         // check if key is in default keys, if not, it's custom, we won't remove it.
         const isCustom = defaultKeys.filter(defaultKey => key.indexOf(defaultKeyring[defaultKey]) === 0).length === 0;
         // check if key explicitly allowed, if not, we'll remove it.
-        const found = isCustom || allowedKeys.find(allowedKey => {
+        const found = isCustom || find(allowedKeys, allowedKey => {
           const allowedKeyName = defaultKeyring[allowedKey];
           // we're looking to see if the key exactly starts with one of our default keys.
           // (which hopefully means it's not custom)

--- a/test/spec/modules/appnexusBidAdapter_spec.js
+++ b/test/spec/modules/appnexusBidAdapter_spec.js
@@ -822,11 +822,12 @@ describe('AppNexusAdapter', function () {
       expect(request.options).to.deep.equal({withCredentials: false});
     });
 
-    it('should populate eids when ttd id and criteo is available', function () {
+    it('should populate eids when supported userIds are available', function () {
       const bidRequest = Object.assign({}, bidRequests[0], {
         userId: {
           tdid: 'sample-userid',
-          criteoId: 'sample-criteo-userid'
+          criteoId: 'sample-criteo-userid',
+          netId: 'sample-netId-userid'
         }
       });
 
@@ -841,6 +842,11 @@ describe('AppNexusAdapter', function () {
       expect(payload.eids).to.deep.include({
         source: 'criteo.com',
         id: 'sample-criteo-userid',
+      });
+
+      expect(payload.eids).to.deep.include({
+        source: 'netid.de',
+        id: 'sample-netId-userid',
       });
     });
 

--- a/test/spec/modules/riseBidAdapter_spec.js
+++ b/test/spec/modules/riseBidAdapter_spec.js
@@ -1,0 +1,363 @@
+import { expect } from 'chai';
+import { spec } from 'modules/riseBidAdapter.js';
+import { newBidder } from 'src/adapters/bidderFactory.js';
+import { config } from 'src/config.js';
+import { VIDEO } from '../../../src/mediaTypes.js';
+
+const ENDPOINT = 'https://hb.yellowblue.io/hb';
+const TEST_ENDPOINT = 'https://hb.yellowblue.io/hb-test';
+const TTL = 360;
+
+describe('riseAdapter', function () {
+  const adapter = newBidder(spec);
+
+  describe('inherited functions', function () {
+    it('exists and is a function', function () {
+      expect(adapter.callBids).to.exist.and.to.be.a('function');
+    });
+  });
+
+  describe('isBidRequestValid', function () {
+    const bid = {
+      'bidder': spec.code,
+      'adUnitCode': 'adunit-code',
+      'sizes': [['640', '480']],
+      'params': {
+        'org': 'jdye8weeyirk00000001'
+      }
+    };
+
+    it('should return true when required params are passed', function () {
+      expect(spec.isBidRequestValid(bid)).to.equal(true);
+    });
+
+    it('should return false when required params are not found', function () {
+      const newBid = Object.assign({}, bid);
+      delete newBid.params;
+      newBid.params = {
+        'org': null
+      };
+      expect(spec.isBidRequestValid(newBid)).to.equal(false);
+    });
+  });
+
+  describe('buildRequests', function () {
+    const bidRequests = [
+      {
+        'bidder': spec.code,
+        'adUnitCode': 'adunit-code',
+        'sizes': [[640, 480]],
+        'params': {
+          'org': 'jdye8weeyirk00000001'
+        },
+        'bidId': '299ffc8cca0b87',
+        'bidderRequestId': '1144f487e563f9',
+        'auctionId': 'bfc420c3-8577-4568-9766-a8a935fb620d',
+      }
+    ];
+
+    const testModeBidRequests = [
+      {
+        'bidder': spec.code,
+        'adUnitCode': 'adunit-code',
+        'sizes': [[640, 480]],
+        'params': {
+          'org': 'jdye8weeyirk00000001',
+          'testMode': true
+        },
+        'bidId': '299ffc8cca0b87',
+        'bidderRequestId': '1144f487e563f9',
+        'auctionId': 'bfc420c3-8577-4568-9766-a8a935fb620d',
+      }
+    ];
+
+    const bidderRequest = {
+      bidderCode: 'rise',
+    }
+
+    it('sends bid request to ENDPOINT via GET', function () {
+      const requests = spec.buildRequests(bidRequests, bidderRequest);
+      for (const request of requests) {
+        expect(request.url).to.equal(ENDPOINT);
+        expect(request.method).to.equal('GET');
+      }
+    });
+
+    it('sends bid request to test ENDPOINT via GET', function () {
+      const requests = spec.buildRequests(testModeBidRequests, bidderRequest);
+      for (const request of requests) {
+        expect(request.url).to.equal(TEST_ENDPOINT);
+        expect(request.method).to.equal('GET');
+      }
+    });
+
+    it('should send the correct bid Id', function () {
+      const requests = spec.buildRequests(bidRequests, bidderRequest);
+      for (const request of requests) {
+        expect(request.data.bid_id).to.equal('299ffc8cca0b87');
+      }
+    });
+
+    it('should send the correct width and height', function () {
+      const requests = spec.buildRequests(bidRequests, bidderRequest);
+      for (const request of requests) {
+        expect(request.data).to.be.an('object');
+        expect(request.data).to.have.property('width', 640);
+        expect(request.data).to.have.property('height', 480);
+      }
+    });
+
+    it('should respect syncEnabled option', function() {
+      config.setConfig({
+        userSync: {
+          syncEnabled: false,
+          filterSettings: {
+            all: {
+              bidders: '*',
+              filter: 'include'
+            }
+          }
+        }
+      });
+      const requests = spec.buildRequests(bidRequests, bidderRequest);
+      for (const request of requests) {
+        expect(request.data).to.be.an('object');
+        expect(request.data).to.not.have.property('cs_method');
+      }
+    });
+
+    it('should respect "iframe" filter settings', function () {
+      config.setConfig({
+        userSync: {
+          syncEnabled: true,
+          filterSettings: {
+            iframe: {
+              bidders: [spec.code],
+              filter: 'include'
+            }
+          }
+        }
+      });
+      const requests = spec.buildRequests(bidRequests, bidderRequest);
+      for (const request of requests) {
+        expect(request.data).to.be.an('object');
+        expect(request.data).to.have.property('cs_method', 'iframe');
+      }
+    });
+
+    it('should respect "all" filter settings', function () {
+      config.setConfig({
+        userSync: {
+          syncEnabled: true,
+          filterSettings: {
+            all: {
+              bidders: [spec.code],
+              filter: 'include'
+            }
+          }
+        }
+      });
+      const requests = spec.buildRequests(bidRequests, bidderRequest);
+      for (const request of requests) {
+        expect(request.data).to.be.an('object');
+        expect(request.data).to.have.property('cs_method', 'iframe');
+      }
+    });
+
+    it('should send the pixel user sync param if userSync is enabled and no "iframe" or "all" configs are present', function () {
+      config.setConfig({
+        userSync: {
+          syncEnabled: true
+        }
+      });
+      const requests = spec.buildRequests(bidRequests, bidderRequest);
+      for (const request of requests) {
+        expect(request.data).to.be.an('object');
+        expect(request.data).to.have.property('cs_method', 'pixel');
+      }
+    });
+
+    it('should respect total exclusion', function() {
+      config.setConfig({
+        userSync: {
+          syncEnabled: true,
+          filterSettings: {
+            image: {
+              bidders: [spec.code],
+              filter: 'exclude'
+            },
+            iframe: {
+              bidders: [spec.code],
+              filter: 'exclude'
+            }
+          }
+        }
+      });
+      const requests = spec.buildRequests(bidRequests, bidderRequest);
+      for (const request of requests) {
+        expect(request.data).to.be.an('object');
+        expect(request.data).to.not.have.property('cs_method');
+      }
+    });
+
+    it('should have us_privacy param if usPrivacy is available in the bidRequest', function () {
+      const bidderRequestWithUSP = Object.assign({uspConsent: '1YNN'}, bidderRequest);
+      const requests = spec.buildRequests(bidRequests, bidderRequestWithUSP);
+      for (const request of requests) {
+        expect(request.data).to.be.an('object');
+        expect(request.data).to.have.property('us_privacy', '1YNN');
+      }
+    });
+
+    it('should have an empty us_privacy param if usPrivacy is missing in the bidRequest', function () {
+      const requests = spec.buildRequests(bidRequests, bidderRequest);
+      for (const request of requests) {
+        expect(request.data).to.be.an('object');
+        expect(request.data).to.not.have.property('us_privacy');
+      }
+    });
+
+    it('should not send the gdpr param if gdprApplies is false in the bidRequest', function () {
+      const bidderRequestWithGDPR = Object.assign({gdprConsent: {gdprApplies: false}}, bidderRequest);
+      const requests = spec.buildRequests(bidRequests, bidderRequestWithGDPR);
+      for (const request of requests) {
+        expect(request.data).to.be.an('object');
+        expect(request.data).to.not.have.property('gdpr');
+        expect(request.data).to.not.have.property('gdpr_consent');
+      }
+    });
+
+    it('should send the gdpr param if gdprApplies is true in the bidRequest', function () {
+      const bidderRequestWithGDPR = Object.assign({gdprConsent: {gdprApplies: true, consentString: 'test-consent-string'}}, bidderRequest);
+      const requests = spec.buildRequests(bidRequests, bidderRequestWithGDPR);
+      for (const request of requests) {
+        expect(request.data).to.be.an('object');
+        expect(request.data).to.have.property('gdpr', true);
+        expect(request.data).to.have.property('gdpr_consent', 'test-consent-string');
+      }
+    });
+
+    it('should have schain param if it is available in the bidRequest', () => {
+      const schain = {
+        ver: '1.0',
+        complete: 1,
+        nodes: [{ asi: 'indirectseller.com', sid: '00001', hp: 1 }],
+      };
+      bidRequests[0].schain = schain;
+      const requests = spec.buildRequests(bidRequests, bidderRequest);
+      for (const request of requests) {
+        expect(request.data).to.be.an('object');
+        expect(request.data).to.have.property('schain', '1.0,1!indirectseller.com,00001,,,,');
+      }
+    });
+  });
+
+  describe('interpretResponse', function () {
+    const response = {
+      cpm: 12.5,
+      vastXml: '<VAST version="3.0"></VAST>',
+      width: 640,
+      height: 480,
+      requestId: '21e12606d47ba7',
+      netRevenue: true,
+      currency: 'USD'
+    };
+
+    it('should get correct bid response', function () {
+      let expectedResponse = [
+        {
+          requestId: '21e12606d47ba7',
+          cpm: 12.5,
+          width: 640,
+          height: 480,
+          creativeId: '21e12606d47ba7',
+          currency: 'USD',
+          netRevenue: true,
+          ttl: TTL,
+          vastXml: '<VAST version="3.0"></VAST>',
+          mediaType: VIDEO
+        }
+      ];
+      const result = spec.interpretResponse({ body: response });
+      expect(Object.keys(result[0])).to.have.members(Object.keys(expectedResponse[0]));
+    });
+  })
+
+  describe('getUserSyncs', function() {
+    const imageSyncResponse = {
+      body: {
+        userSyncPixels: [
+          'https://image-sync-url.test/1',
+          'https://image-sync-url.test/2',
+          'https://image-sync-url.test/3'
+        ]
+      }
+    };
+
+    const iframeSyncResponse = {
+      body: {
+        userSyncURL: 'https://iframe-sync-url.test'
+      }
+    };
+
+    it('should register all img urls from the response', function() {
+      const syncs = spec.getUserSyncs({ pixelEnabled: true }, [imageSyncResponse]);
+      expect(syncs).to.deep.equal([
+        {
+          type: 'image',
+          url: 'https://image-sync-url.test/1'
+        },
+        {
+          type: 'image',
+          url: 'https://image-sync-url.test/2'
+        },
+        {
+          type: 'image',
+          url: 'https://image-sync-url.test/3'
+        }
+      ]);
+    });
+
+    it('should register the iframe url from the response', function() {
+      const syncs = spec.getUserSyncs({ iframeEnabled: true }, [iframeSyncResponse]);
+      expect(syncs).to.deep.equal([
+        {
+          type: 'iframe',
+          url: 'https://iframe-sync-url.test'
+        }
+      ]);
+    });
+
+    it('should register both image and iframe urls from the responses', function() {
+      const syncs = spec.getUserSyncs({ pixelEnabled: true, iframeEnabled: true }, [iframeSyncResponse, imageSyncResponse]);
+      expect(syncs).to.deep.equal([
+        {
+          type: 'iframe',
+          url: 'https://iframe-sync-url.test'
+        },
+        {
+          type: 'image',
+          url: 'https://image-sync-url.test/1'
+        },
+        {
+          type: 'image',
+          url: 'https://image-sync-url.test/2'
+        },
+        {
+          type: 'image',
+          url: 'https://image-sync-url.test/3'
+        }
+      ]);
+    });
+
+    it('should handle an empty response', function() {
+      const syncs = spec.getUserSyncs({ iframeEnabled: true }, []);
+      expect(syncs).to.deep.equal([]);
+    });
+
+    it('should handle when user syncs are disabled', function() {
+      const syncs = spec.getUserSyncs({ pixelEnabled: false }, [imageSyncResponse]);
+      expect(syncs).to.deep.equal([]);
+    });
+  })
+});

--- a/test/spec/modules/stroeerCoreBidAdapter_spec.js
+++ b/test/spec/modules/stroeerCoreBidAdapter_spec.js
@@ -2,6 +2,7 @@ import {assert} from 'chai';
 import {spec} from 'modules/stroeerCoreBidAdapter.js';
 import * as utils from 'src/utils.js';
 import {BANNER, VIDEO} from '../../../src/mediaTypes.js';
+import find from 'core-js-pure/features/array/find.js';
 
 describe('stroeerCore bid adapter', function () {
   let sandbox;
@@ -123,7 +124,7 @@ describe('stroeerCore bid adapter', function () {
           }
         },
         referrer,
-        getElementById: id => placementElements.find(el => el.id === id)
+        getElementById: id => find(placementElements, el => el.id === id)
       }
     };
 

--- a/test/spec/modules/synacormediaBidAdapter_spec.js
+++ b/test/spec/modules/synacormediaBidAdapter_spec.js
@@ -11,12 +11,19 @@ describe('synacormediaBidAdapter ', function () {
         sizes: [300, 250],
         params: {
           seatId: 'prebid',
-          placementId: '1234'
+          tagId: '1234'
         }
       };
     });
 
     it('should return true when params placementId and seatId are truthy', function () {
+      bid.params.placementId = bid.params.tagId;
+      delete bid.params.tagId;
+      assert(spec.isBidRequestValid(bid));
+    });
+
+    it('should return true when params tagId and seatId are truthy', function () {
+      delete bid.params.placementId;
       assert(spec.isBidRequestValid(bid));
     });
 
@@ -35,8 +42,9 @@ describe('synacormediaBidAdapter ', function () {
       assert.isFalse(spec.isBidRequestValid(bid));
     });
 
-    it('should return false when placementId param is missing', function () {
+    it('should return false when both placementId param and tagId param are missing', function () {
       delete bid.params.placementId;
+      delete bid.params.tagId;
       assert.isFalse(spec.isBidRequestValid(bid));
     });
 
@@ -53,7 +61,7 @@ describe('synacormediaBidAdapter ', function () {
       sizes: [[300, 250], [300, 600]],
       params: {
         seatId: 'prebid',
-        placementId: '1234',
+        tagId: '1234',
         bidfloor: '0.50'
       }
     };
@@ -63,7 +71,7 @@ describe('synacormediaBidAdapter ', function () {
       sizes: [[300, 250], [300, 600]],
       params: {
         seatId: 'prebid',
-        placementId: '1234',
+        tagId: '1234',
         bidfloor: '0.50'
       },
       mediaTypes: {
@@ -84,7 +92,7 @@ describe('synacormediaBidAdapter ', function () {
       sizes: [[640, 480]],
       params: {
         seatId: 'prebid',
-        placementId: '1234',
+        tagId: '1234',
         bidfloor: '0.50'
       },
       mediaTypes: {
@@ -110,7 +118,7 @@ describe('synacormediaBidAdapter ', function () {
       bidder: 'synacormedia',
       params: {
         seatId: 'prebid',
-        placementId: '1234',
+        tagId: '1234',
         video: {
           minduration: 30
         }
@@ -163,7 +171,7 @@ describe('synacormediaBidAdapter ', function () {
       sizes: [[300, 250], [300, 600]],
       params: {
         seatId: 'prebid',
-        placementId: '1234',
+        tagId: '1234',
         bidfloor: '0.50'
       }
     };
@@ -230,7 +238,7 @@ describe('synacormediaBidAdapter ', function () {
         sizes: [[300, 600]],
         params: {
           seatId: validBidRequest.params.seatId,
-          placementId: '5678',
+          tagId: '5678',
           bidfloor: '0.50'
         }
       };
@@ -262,7 +270,7 @@ describe('synacormediaBidAdapter ', function () {
         sizes: [[300, 250]],
         params: {
           seatId: 'somethingelse',
-          placementId: '5678',
+          tagId: '5678',
           bidfloor: '0.50'
         }
       };
@@ -295,7 +303,7 @@ describe('synacormediaBidAdapter ', function () {
         sizes: [[300, 250]],
         params: {
           seatId: 'prebid',
-          placementId: '1234',
+          tagId: '1234',
           bidfloor: 'abcd'
         }
       };
@@ -327,7 +335,7 @@ describe('synacormediaBidAdapter ', function () {
         sizes: [[300, 250]],
         params: {
           seatId: 'prebid',
-          placementId: '1234'
+          tagId: '1234'
         }
       };
       let req = spec.buildRequests([badFloorBidRequest], bidderRequest);
@@ -358,7 +366,7 @@ describe('synacormediaBidAdapter ', function () {
         sizes: [[300, 250]],
         params: {
           seatId: 'prebid',
-          placementId: '1234',
+          tagId: '1234',
           pos: 1
         }
       };
@@ -390,7 +398,7 @@ describe('synacormediaBidAdapter ', function () {
         sizes: [[300, 250]],
         params: {
           seatId: 'prebid',
-          placementId: '1234',
+          tagId: '1234',
         }
       };
       let req = spec.buildRequests([newPosBidRequest], bidderRequest);
@@ -425,7 +433,7 @@ describe('synacormediaBidAdapter ', function () {
         sizes: [],
         params: {
           seatId: 'prebid',
-          placementId: '1234',
+          tagId: '1234',
           bidfloor: '0.50'
         }
       };
@@ -435,7 +443,7 @@ describe('synacormediaBidAdapter ', function () {
         sizes: [[300]],
         params: {
           seatId: 'prebid',
-          placementId: '1234',
+          tagId: '1234',
           bidfloor: '0.50'
         }
       };
@@ -457,7 +465,7 @@ describe('synacormediaBidAdapter ', function () {
         bidder: 'synacormedia',
         params: {
           seatId: 'prebid',
-          placementId: '1234',
+          tagId: '1234',
           video: {
             minduration: 30,
             maxduration: 45,
@@ -515,7 +523,7 @@ describe('synacormediaBidAdapter ', function () {
         bidder: 'synacormedia',
         params: {
           seatId: 'prebid',
-          placementId: '1234',
+          tagId: '1234',
           video: {
             minduration: 30,
             maxduration: 45,
@@ -582,12 +590,74 @@ describe('synacormediaBidAdapter ', function () {
     })
   });
 
+  describe('Bid Requests with placementId should be backward compatible ', function () {
+    let validVideoBidReq = {
+      bidder: 'synacormedia',
+      params: {
+        seatId: 'prebid',
+        placementId: 'demo1',
+        pos: 1,
+        video: {}
+      },
+      renderer: {
+        url: '../syncOutstreamPlayer.js'
+      },
+      mediaTypes: {
+        video: {
+          playerSize: [[300, 250]],
+          context: 'outstream'
+        }
+      },
+      adUnitCode: 'div-1',
+      transactionId: '0869f34e-090b-4b20-84ee-46ff41405a39',
+      sizes: [[300, 250]],
+      bidId: '22b3a2268d9f0e',
+      bidderRequestId: '1d195910597e13',
+      auctionId: '3375d336-2aea-4ee7-804c-6d26b621ad20',
+      src: 'client',
+      bidRequestsCount: 1,
+      bidderRequestsCount: 1,
+      bidderWinsCount: 0
+    };
+
+    let validBannerBidRequest = {
+      bidId: '9876abcd',
+      sizes: [[300, 250]],
+      params: {
+        seatId: 'prebid',
+        placementId: '1234',
+      }
+    };
+
+    let bidderRequest = {
+      refererInfo: {
+        referer: 'http://localhost:9999/'
+      },
+      bidderCode: 'synacormedia',
+      auctionId: 'f8a75621-d672-4cbb-9275-3db7d74fb110'
+    };
+
+    it('should return valid bid request for banner impression', function () {
+      let req = spec.buildRequests([validBannerBidRequest], bidderRequest);
+      expect(req).to.have.property('method', 'POST');
+      expect(req).to.have.property('url');
+      expect(req.url).to.contain('//prebid.technoratimedia.com/openrtb/bids/prebid?src=$$REPO_AND_VERSION$$');
+    });
+
+    it('should return valid bid request for video impression', function () {
+      let req = spec.buildRequests([validVideoBidReq], bidderRequest);
+      expect(req).to.have.property('method', 'POST');
+      expect(req).to.have.property('url');
+      expect(req.url).to.contain('//prebid.technoratimedia.com/openrtb/bids/prebid?src=$$REPO_AND_VERSION$$');
+    });
+  });
+
   describe('Bid Requests with schain object ', function() {
     let validBidReq = {
       bidder: 'synacormedia',
       params: {
         seatId: 'prebid',
-        placementId: 'demo1',
+        tagId: 'demo1',
         pos: 1,
         video: {}
       },
@@ -634,7 +704,7 @@ describe('synacormediaBidAdapter ', function () {
           bidder: 'synacormedia',
           params: {
             seatId: 'prebid',
-            placementId: 'demo1',
+            tagId: 'demo1',
             pos: 1,
             video: {}
           },
@@ -914,8 +984,8 @@ describe('synacormediaBidAdapter ', function () {
       });
 
       let resp = spec.interpretResponse(serverRespVideo, bidRequest);
-	  sandbox.restore();
-	  expect(resp[0].videoCacheKey).to.not.exist;
+	    sandbox.restore();
+	    expect(resp[0].videoCacheKey).to.not.exist;
     });
 
     it('should use video bid request height and width if not present in response', function () {

--- a/test/spec/modules/temedyaBidAdapter_spec.js
+++ b/test/spec/modules/temedyaBidAdapter_spec.js
@@ -1,0 +1,177 @@
+import {expect} from 'chai';
+import {spec} from 'modules/temedyaBidAdapter.js';
+import * as utils from 'src/utils.js';
+
+const ENDPOINT_URL = 'https://adm.vidyome.com/';
+
+export const _getUrlVars = function(url) {
+  var hash;
+  var myJson = {};
+  var hashes = url.slice(url.indexOf('?') + 1).split('&');
+  for (var i = 0; i < hashes.length; i++) {
+    hash = hashes[i].split('=');
+    myJson[hash[0]] = hash[1];
+  }
+  return myJson;
+}
+
+describe('temedya adapter', function() {
+  let bidRequests;
+  let nativeBidRequests;
+
+  beforeEach(function() {
+    bidRequests = [
+      {
+        bidder: 'temedya',
+        params: {
+          widgetId: 753497,
+          count: 1
+        },
+        mediaTypes: {
+          banner: {
+            sizes: [[300, 250]]
+          }
+        }
+      }
+    ]
+
+    nativeBidRequests = [
+      {
+        bidder: 'temedya',
+        params: {
+          widgetId: 753497,
+          count: 1
+        },
+        nativeParams: {
+          title: {
+            required: true
+          },
+          image: {
+            required: true
+          }
+        }
+      }
+    ]
+  })
+
+  describe('isBidRequestValid', function () {
+    it('valid bid case', function () {
+      let validBid = {
+        bidder: 'temedya',
+        params: {
+          widgetId: 753497,
+          count: 1
+        }
+      }
+      let isValid = spec.isBidRequestValid(validBid);
+      expect(isValid).to.equal(true);
+    });
+
+    it('invalid bid case: widgetId and countId is not passed', function() {
+      let validBid = {
+        bidder: 'temedya',
+        params: {
+        }
+      }
+      let isValid = spec.isBidRequestValid(validBid);
+      expect(isValid).to.equal(false);
+    })
+  })
+
+  describe('buildRequests', function () {
+    it('sends bid request to ENDPOINT via GET', function () {
+      const request = spec.buildRequests(bidRequests)[0];
+      expect(request.url).to.include(ENDPOINT_URL);
+      expect(request.method).to.equal('GET');
+    });
+
+    it('buildRequests function should not modify original bidRequests object', function () {
+      let originalBidRequests = utils.deepClone(bidRequests);
+      let request = spec.buildRequests(bidRequests);
+      expect(bidRequests).to.deep.equal(originalBidRequests);
+    });
+
+    it('buildRequests function should not modify original nativeBidRequests object', function () {
+      let originalBidRequests = utils.deepClone(nativeBidRequests);
+      let request = spec.buildRequests(nativeBidRequests);
+      expect(nativeBidRequests).to.deep.equal(originalBidRequests);
+    });
+
+    it('Request params check', function() {
+      let request = spec.buildRequests(bidRequests)[0];
+      const data = _getUrlVars(request.url)
+      data.type = 'native';
+      data.wid = bidRequests[0].params.widgetId;
+      data.count = bidRequests[0].params.count;
+    })
+  })
+
+  describe('interpretResponse', function () {
+    let response = {
+      ads: [
+        {
+          'id': 30,
+          'name': 'Pro Trader Desktop Ocak',
+          'assets': {
+            'sponsor': 'Yatırım Bülteni',
+            'cpm': '0.30188070875464',
+            'name': 'SLC2-DESKTOP',
+            'files': [
+              'https://dsp-vidyome.cdn.vidyome.com/dsp/assets/84066_SLC2_640X480_82KB.jpg'
+            ],
+            'id': 9,
+            'title': '6 ayda zengin oldu! Günde 2 saat çalışarak bilgisayar başında zengin oldu.',
+            'body': 'Sizde yapabilirsiniz!',
+            'landing_url': 'https://bit.ly/3l6RhKG',
+            'click_url': 'https://adclick.adm.vidyome.com/collect?campaignId=30&creativeId=9&widId=122129&v=1609960813742&uri=https%3A%2F%2Fbit.ly%2F3l6RhKG%3Futm_source%3DVidyome%26utm_medium%3Dnative%26utm_campaign%3D30%26utm_term%3D9%26utm_content%3D122129'
+          },
+          'conversion_urls': [
+
+          ],
+          'impression_urls': [
+
+          ]
+        }
+      ],
+      base: {
+        'isSmartphone': false,
+        'isTablet': false,
+        'isDesktop': true,
+        'isConnectedTv': false,
+        'country': 'tr',
+        'wid': 753497,
+        'type': 'native',
+        'locale': 'tr',
+        'widget': {
+          'click': 'https://stats.vidyome.com/s/widgets/collect?widgetId=122129&eventType=click',
+          'impression': 'https://impression.adm.vidyome.com/collect/v1?widgetId=122129'
+        }
+      },
+    };
+
+    it('should get correct bid response', function () {
+      let expectedResponse = [
+        {
+          'requestId': '1d236f7890b',
+          'cpm': 0.0920,
+          'width': 300,
+          'height': 250,
+          'netRevenue': false,
+          'mediaType': 'native',
+          'currency': 'TRY',
+          'creativeId': '<!-- CREATIVE ID -->',
+          'ttl': 700,
+          'ad': '<!-- ADS TAG -->'
+        }
+      ];
+      let request = spec.buildRequests(bidRequests)[0];
+      let result = spec.interpretResponse({body: response}, request);
+      expect(Object.keys(result[0])).to.have.members(Object.keys(expectedResponse[0]));
+      expect(result[0].cpm).to.not.equal(null);
+      expect(result[0].creativeId).to.not.equal(null);
+      expect(result[0].ad).to.not.equal(null);
+      expect(result[0].currency).to.equal('TRY');
+      expect(result[0].netRevenue).to.equal(false);
+    });
+  })
+})

--- a/test/spec/modules/ucfunnelBidAdapter_spec.js
+++ b/test/spec/modules/ucfunnelBidAdapter_spec.js
@@ -1,13 +1,23 @@
 import { expect } from 'chai';
 import { spec } from 'modules/ucfunnelBidAdapter.js';
 import {BANNER, VIDEO, NATIVE} from 'src/mediaTypes.js';
-
 const URL = 'https://hb.aralego.com/header';
 const BIDDER_CODE = 'ucfunnel';
 
 const bidderRequest = {
   uspConsent: '1YNN'
 };
+
+const userId = {
+  'criteoId': 'vYlICF9oREZlTHBGRVdrJTJCUUJnc3U2ckNVaXhrV1JWVUZVSUxzZmJlcnJZR0ZxbVhFRnU5bDAlMkJaUWwxWTlNcmdEeHFrJTJGajBWVlV4T3lFQ0FyRVcxNyUyQlIxa0lLSlFhcWJpTm9PSkdPVkx0JTJCbzlQRTQlM0Q',
+  'id5id': {'uid': 'ID5-8ekgswyBTQqnkEKy0ErmeQ1GN5wV4pSmA-RE4eRedA'},
+  'netId': 'fH5A3n2O8_CZZyPoJVD-eabc6ECb7jhxCicsds7qSg',
+  'parrableId': {'eid': '01.1608624401.fe44bca9b96873084a0d4e9d0ac5729f13790ba8f8e58fa4707b6b3c096df91c6b5f254992bdad4ab1dd4a89919081e9b877d7a039ac3183709277665bac124f28e277d109f0ff965058'},
+  'pubcid': 'd8aa10fa-d86c-451d-aad8-5f16162a9e64',
+  'sharedid': {'id': '01ESHXW4HD29KMF387T63JQ9H5', 'third': '01ESHXW4HD29KMF387T63JQ9H5'},
+  'tdid': 'D6885E90-2A7A-4E0F-87CB-7734ED1B99A3',
+  'haloId': {}
+}
 
 const validBannerBidReq = {
   bidder: BIDDER_CODE,
@@ -18,6 +28,7 @@ const validBannerBidReq = {
   sizes: [[300, 250]],
   bidId: '263be71e91dd9d',
   auctionId: '9ad1fa8d-2297-4660-a018-b39945054746',
+  userId: userId,
   'schain': {
     'ver': '1.0',
     'complete': 1,
@@ -50,7 +61,8 @@ const validBannerBidRes = {
   adm: '<html style="height:100%"><body style="width:300px;height: 100%;padding:0;margin:0 auto;"><div style="width:100%;height:100%;display:table;"><div style="width:100%;height:100%;display:table-cell;text-align:center;vertical-align:middle;"><a href="//www.ucfunnel.com/" target="_blank"><img src="//cdn.aralego.net/ucfad/house/ucf/AdGent-300x250.jpg" width="300px" height="250px" align="middle" style="border:none"></a></div></div></body></html>',
   cpm: 1.01,
   height: 250,
-  width: 300
+  width: 300,
+  crid: 'test-crid'
 };
 
 const invalidBannerBidRes = '';
@@ -110,6 +122,13 @@ const validNativeBidRes = {
   cpm: 1.01,
   height: 1,
   width: 1
+};
+
+const gdprConsent = {
+  consentString: 'CO9rhBTO9rhBTAcABBENBCCsAP_AAH_AACiQHItf_X_fb3_j-_59_9t0eY1f9_7_v20zjgeds-8Nyd_X_L8X42M7vB36pq4KuR4Eu3LBIQdlHOHcTUmw6IkVqTPsbk2Mr7NKJ7PEinMbe2dYGH9_n9XTuZKY79_s___z__-__v__7_f_r-3_3_vp9V---3YHIgEmGpfARZiWOBJNGlUKIEIVxIdACACihGFomsICVwU7K4CP0EDABAagIwIgQYgoxZBAAAAAElEQEgB4IBEARAIAAQAqQEIACNAEFgBIGAQACgGhYARQBCBIQZHBUcpgQESLRQTyVgCUXexhhCGUUANAg4AA.YAAAAAAAAAAA',
+  vendorData: {},
+  gdprApplies: true,
+  apiVersion: 2
 };
 
 describe('ucfunnel Adapter', function () {
@@ -253,18 +272,18 @@ describe('ucfunnel Adapter', function () {
 
   describe('cookie sync', function () {
     describe('cookie sync iframe', function () {
-      const result = spec.getUserSyncs({'iframeEnabled': true});
+      const result = spec.getUserSyncs({'iframeEnabled': true}, null, gdprConsent);
 
       it('should return cookie sync iframe info', function () {
         expect(result[0].type).to.equal('iframe');
-        expect(result[0].url).to.equal('https://cdn.aralego.net/ucfad/cookie/sync.html');
+        expect(result[0].url).to.equal('https://cdn.aralego.net/ucfad/cookie/sync.html?gdpr=1&euconsent-v2=CO9rhBTO9rhBTAcABBENBCCsAP_AAH_AACiQHItf_X_fb3_j-_59_9t0eY1f9_7_v20zjgeds-8Nyd_X_L8X42M7vB36pq4KuR4Eu3LBIQdlHOHcTUmw6IkVqTPsbk2Mr7NKJ7PEinMbe2dYGH9_n9XTuZKY79_s___z__-__v__7_f_r-3_3_vp9V---3YHIgEmGpfARZiWOBJNGlUKIEIVxIdACACihGFomsICVwU7K4CP0EDABAagIwIgQYgoxZBAAAAAElEQEgB4IBEARAIAAQAqQEIACNAEFgBIGAQACgGhYARQBCBIQZHBUcpgQESLRQTyVgCUXexhhCGUUANAg4AA.YAAAAAAAAAAA&');
       });
     });
     describe('cookie sync image', function () {
-      const result = spec.getUserSyncs({'pixelEnabled': true});
+      const result = spec.getUserSyncs({'pixelEnabled': true}, null, gdprConsent);
       it('should return cookie sync image info', function () {
         expect(result[0].type).to.equal('image');
-        expect(result[0].url).to.equal('https://sync.aralego.com/idSync');
+        expect(result[0].url).to.equal('https://sync.aralego.com/idSync?gdpr=1&euconsent-v2=CO9rhBTO9rhBTAcABBENBCCsAP_AAH_AACiQHItf_X_fb3_j-_59_9t0eY1f9_7_v20zjgeds-8Nyd_X_L8X42M7vB36pq4KuR4Eu3LBIQdlHOHcTUmw6IkVqTPsbk2Mr7NKJ7PEinMbe2dYGH9_n9XTuZKY79_s___z__-__v__7_f_r-3_3_vp9V---3YHIgEmGpfARZiWOBJNGlUKIEIVxIdACACihGFomsICVwU7K4CP0EDABAagIwIgQYgoxZBAAAAAElEQEgB4IBEARAIAAQAqQEIACNAEFgBIGAQACgGhYARQBCBIQZHBUcpgQESLRQTyVgCUXexhhCGUUANAg4AA.YAAAAAAAAAAA&');
       });
     });
   });

--- a/test/spec/modules/userId_spec.js
+++ b/test/spec/modules/userId_spec.js
@@ -23,6 +23,7 @@ import {
   setConsentConfig
 } from 'modules/consentManagement.js';
 import {server} from 'test/mocks/xhr.js';
+import find from 'core-js-pure/features/array/find.js';
 import {unifiedIdSubmodule} from 'modules/unifiedIdSystem.js';
 import {pubCommonIdSubmodule} from 'modules/pubCommonIdSystem.js';
 import {britepoolIdSubmodule} from 'modules/britepoolIdSystem.js';
@@ -87,7 +88,7 @@ describe('User ID', function () {
   }
 
   function findEid(eids, source) {
-    return eids.find((eid) => {
+    return find(eids, (eid) => {
       if (eid.source === source) { return true; }
     });
   }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Adds Global Vendor List (GVL) ID for Lotame (95) to the lotamePanoramaIdSystem User ID module as a property and in getting a storage manager. The understanding is this will prevent the GDPR Enforcement module from blocking this module. I don't believe there are any other changes needed to our module directly. It is then on the publisher to set up the pbjc consentManagement config section as appropriate.


- contact email of the adapter’s maintainer: mconrad@lotame.com
- [ ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
