### PR TITLE
Feature/grue 176 prebid tests

### DIFF
--- a/modules/lotamePanoramaIdSystem.js
+++ b/modules/lotamePanoramaIdSystem.js
@@ -84,9 +84,11 @@ function getFromStorage(key) {
 /**
  * Returns the domain used to host the ID request 
  */
-function getIDHost() {
-  let idHost = DEV_ID_HOST;
-  return idHost;
+function getIDHost(config) {
+  if (config && config['environment'] && config['environment'] == 'dev') {
+    return DEV_ID_HOST;
+  }
+  return ID_HOST;
 }
 
 /**
@@ -238,7 +240,7 @@ export const lotamePanoramaIdSubmodule = {
       }
       const url = buildUrl({
         protocol: 'https',
-        host: getIDHost(),
+        host: getIDHost(config),
         pathname: '/id',
         search: isEmpty(queryParams) ? undefined : queryParams,
       });

--- a/modules/lotamePanoramaIdSystem.js
+++ b/modules/lotamePanoramaIdSystem.js
@@ -18,6 +18,8 @@ const DAYS_TO_CACHE = 7;
 const DAY_MS = 60 * 60 * 24 * 1000;
 const MISSING_CORE_CONSENT = 111;
 const GVLID = 95;
+const ID_HOST = 'id.crwdcntrl.net';
+const DEV_ID_HOST = 'id.dev.lotame.com';
 
 export const storage = getStorageManager(GVLID, MODULE_NAME);
 let cookieDomain;
@@ -77,6 +79,14 @@ function getFromStorage(key) {
     }
   }
   return value;
+}
+
+/**
+ * Returns the domain used to host the ID request 
+ */
+function getIDHost() {
+  let idHost = DEV_ID_HOST;
+  return idHost;
 }
 
 /**
@@ -228,7 +238,7 @@ export const lotamePanoramaIdSubmodule = {
       }
       const url = buildUrl({
         protocol: 'https',
-        host: `id.crwdcntrl.net`,
+        host: getIDHost(),
         pathname: '/id',
         search: isEmpty(queryParams) ? undefined : queryParams,
       });

--- a/test/spec/modules/lotamePanoramaIdSystem_spec.js
+++ b/test/spec/modules/lotamePanoramaIdSystem_spec.js
@@ -65,8 +65,7 @@ describe('LotameId', function() {
     });
 
     it('should call the remote server when getId is called', function () {
-      expect(request.url).to.be.eq('https://id.crwdcntrl.net/id');
-
+      expect(request.url).to.be.eq(`https://${lotamePanoramaIdSubmodule.getIDHost()}/id`);
       expect(callBackSpy.calledOnce).to.be.true;
     });
 


### PR DESCRIPTION
Change to facilitate testing for the Lotame Panorama ID Submodule by allowing it to use a development URL for the id endpoint.

## Type of change
Feature

## Description of change
In the submodule, getId will look to an optional configuration value to determine whether to use the development or production URL for our id endpoint.
